### PR TITLE
Support HEMCO grid configuration and change HEMCO-CESM remote to ESCOMP

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -77,9 +77,9 @@ local_path = src/chemistry/geoschem/geoschem_src
 required = True
 
 [hemco]
-branch = feature/hemco_3.5.0
+tag = hemco-cesm1_0_hemco_3_5_0
 protocol = git
-repo_url = https://github.com/lizziel/HEMCO_CESM.git
+repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 local_path = src/hemco
 required = True
 externals = Externals_HCO.cfg

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -77,7 +77,7 @@ local_path = src/chemistry/geoschem/geoschem_src
 required = True
 
 [hemco]
-tag = hemco-cesm1_0_hemco_3_5_0
+tag = hemco-cesm1_0_hemco_3_5_1
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 local_path = src/hemco

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -3227,4 +3227,16 @@
 
 <focndomain hgrid="1.9x2.5" ocn="som">atm/cam/ocnfrac/domain.aqua.fv1.9x2.5.nc</focndomain>
 
+<!-- HEMCO -->
+<hemco_config_file>HEMCO_Config.rc</hemco_config_file>
+
+<hemco_grid_xdim hgrid="ne30np4">288</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="ne30np4">201</hemco_grid_ydim>
+
+<hemco_grid_xdim hgrid="0.9x1.25">288</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="0.9x1.25">201</hemco_grid_ydim>
+
+<hemco_grid_xdim hgrid="1.9x2.5">144</hemco_grid_xdim>
+<hemco_grid_ydim hgrid="1.9x2.5">91</hemco_grid_ydim>
+
 </namelist_defaults>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4887,6 +4887,18 @@ Full pathname to HEMCO_Config.rc, which prescribes emission inventories
 Default: set by build-namelist.
 </entry>
 
+<entry id="hemco_grid_xdim" type="integer" category="hemco"
+       group="hemco_nl" valid_values="">
+Number of x-dimensions in HEMCO internal grid.
+Default: set by build-namelist.
+</entry>
+
+<entry id="hemco_grid_ydim" type="integer" category="hemco"
+       group="hemco_nl" valid_values="">
+Number of y-dimensions in HEMCO internal grid.
+Default: set by build-namelist.
+</entry>
+
 <!-- Reference Pressures -->
 
 <entry id="trop_cloud_top_press" type="real" category="press_lim"


### PR DESCRIPTION
This is a cherry-pick from https://github.com/CESM-GC/CAM/commit/1e62f7f847205f98eab4b22c67d3ca578193cfdb

Adds `hemco_grid_xdim` and `hemco_grid_ydim` parameters to `&hemco` (with defaults for `0.9x1.25`, `1.9x2.5`, and `ne30np4` grids) to configure HEMCO intermediate grid resolution in the atm namelist.

Also needs updates to the HEMCO-CESM external. I've added a new tag https://github.com/ESCOMP/HEMCO_CESM/tree/hemco-cesm1_0_hemco3_5_0 (`hemco-cesm1_0_hemco_3_5_0`) which will also be the version targeted to merge HEMCO-CESM into the trunk for CAM-chem. Will include in later commit