### PR TITLE
Fix bug that was forcing HEMCO_Config.rc as hemco_config_file

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2841,7 +2841,6 @@ else {
 }
 
 # HEMCO
-$nl->set_variable_value('hemco_nl', 'hemco_config_File', "'HEMCO_Config.rc'");
 my $hco = $cfg->get('hemco');
 if ( $hco eq '1' ) {
     add_default($nl, 'cam_physics_mesh');


### PR DESCRIPTION
Removes a clause that forced the HEMCO config file parameter to always be `HEMCO_Config.rc`. This isn't present in `HEMCO-CESM_rebased_on_cam6_3_045` so maybe it snuck in at some point when merging the HEMCO-CESM code into CESM-GC.

Thanks!
Haipeng