### PR TITLE
Support HEMCO_CESM v1.1.0 & HEMCO 3.6.0

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -84,7 +84,7 @@ local_path = src/chemistry/geoschem/geoschem_src
 required = True
 
 [hemco]
-tag = hemco-cesm1_1_0_hemco3_6_0
+tag = hemco-cesm1_1_1_hemco3_6_2
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 local_path = src/hemco

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -84,7 +84,7 @@ local_path = src/chemistry/geoschem/geoschem_src
 required = True
 
 [hemco]
-tag = hemco-cesm1_0_hemco3_5_1
+tag = hemco-cesm1_1_0_hemco3_6_0
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 local_path = src/hemco

--- a/src/chemistry/geoschem/cesmgc_emissions_mod.F90
+++ b/src/chemistry/geoschem/cesmgc_emissions_mod.F90
@@ -52,9 +52,12 @@ MODULE CESMGC_Emissions_Mod
   INTEGER,  ALLOCATABLE :: megan_indices_map(:) 
   REAL(r8), ALLOCATABLE :: megan_wght_factors(:)
 
+  ! Cache for is_extfrc?
+  LOGICAL :: pcnst_is_extfrc(iFirstCnst:pcnst) ! no idea why the indexing is not 1:gas_pcnst or why iFirstCnst can be < 0
 !
 ! !REVISION HISTORY:
 !  07 Oct 2020 - T. M. Fritz   - Initial version
+!  20 Jan 2023 - H.P. Lin      - Update for 2D/3D pbuf switches
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -80,7 +83,7 @@ CONTAINS
     USE PHYSICS_TYPES,       ONLY : physics_state
     USE CONSTITUENTS,        ONLY : cnst_get_ind
     USE PHYS_CONTROL,        ONLY : phys_getopts
-    USE MO_CHEM_UTLS,        ONLY : get_spc_ndx
+    USE MO_CHEM_UTLS,        ONLY : get_spc_ndx, get_extfrc_ndx
     USE CAM_HISTORY,         ONLY : addfld, add_default, horiz_only
     USE MO_LIGHTNING,        ONLY : lightning_inti
     USE FIRE_EMISSIONS,      ONLY : fire_emissions_init
@@ -244,6 +247,12 @@ CONTAINS
     !-----------------------------------------------------------------------
     CALL fire_emissions_init()
 
+    ! Initialize pcnst_is_extfrc cache to avoid lengthy lookups in future timesteps
+    ! on the get_extfrc_ndx routine. (hplin 1/20/23)
+    do n = iFirstCnst, pcnst
+       pcnst_is_extfrc(n) = (get_extfrc_ndx(trim(cnst_name(n))) > 0)
+    enddo
+
   END SUBROUTINE CESMGC_Emissions_Init
 !EOC
 !------------------------------------------------------------------------------
@@ -368,16 +377,32 @@ CONTAINS
        ELSE
           ! This is already in chunk, retrieve it
           pbuf_chnk => pbuf_get_chunk(hco_pbuf2d, LCHNK)
-          CALL pbuf_get_field(pbuf_chnk, tmpIdx, pbuf_ik)
 
-          IF ( .NOT. ASSOCIATED(pbuf_ik) ) THEN ! Sanity check
-             CALL ENDRUN("CESMGC_Emissions_Calc: FATAL - tmpIdx > 0 but pbuf_ik not associated")
+          ! Check if we need to get 3-D, or 2-D data
+          IF (pcnst_is_extfrc(N)) THEN
+             CALL pbuf_get_field(pbuf_chnk, tmpIdx, pbuf_ik)
+
+             IF ( .NOT. ASSOCIATED(pbuf_ik) ) THEN ! Sanity check
+                CALL ENDRUN("CESMGC_Emissions_Calc: FATAL - tmpIdx > 0 but pbuf_ik not associated (E-1)")
+             ENDIF
+
+             eflx(1:nY,:nZ,N) = pbuf_ik(1:nY,:nZ)
+
+             ! Reset pointers
+             pbuf_ik   => NULL()
+          ELSE ! 2-D
+             CALL pbuf_get_field(pbuf_chnk, tmpIdx, pbuf_i)
+
+             IF ( .NOT. ASSOCIATED(pbuf_i) ) THEN ! Sanity check
+                CALL ENDRUN("CESMGC_Emissions_Calc: FATAL - tmpIdx > 0 but pbuf_i not associated (E-2)")
+             ENDIF
+
+             eflx(1:nY,:nZ,N) = pbuf_i(1:nY)
+
+             ! Reset pointers
+             pbuf_i    => NULL()
           ENDIF
 
-          eflx(1:nY,:nZ,N) = pbuf_ik(1:nY,:nZ)
-
-          ! Reset pointers
-          pbuf_ik   => NULL()
           pbuf_chnk => NULL()
 
           !IF ( MINVAL(eflx(:nY,:nZ,N)) < 0.0e+00_r8 ) THEN

--- a/src/chemistry/geoschem/chem_mods.F90
+++ b/src/chemistry/geoschem/chem_mods.F90
@@ -69,7 +69,7 @@
                             relcnt = 0, & ! number of relationship species
                             grpcnt = 0, & ! number of group members
                             nzcnt = 824, & ! number of non-zero matrix entries
-                            extcnt = 0, & ! number of species with external forcing
+                            extcnt = 34, & ! number of species with external forcing, aka 3-D emissions
                             clscnt1 = 8, & ! number of species in explicit class
                             clscnt2 = 0, & ! number of species in hov class
                             clscnt3 = 0, & ! number of species in ebi class

--- a/src/chemistry/geoschem/mo_sim_dat.F90
+++ b/src/chemistry/geoschem/mo_sim_dat.F90
@@ -237,9 +237,25 @@
                           250.445000_r8, 250.445000_r8, 250.445000_r8, 250.445000_r8, 250.445000_r8, &
                            44.010000_r8, 33.0100000_r8, 17.0100000_r8  /)
 
-      extfrc_lst(: 1) = (/ '                ' /)
+      extfrc_lst(: 34) = (/ 'NO              ', 'CO              ', 'SO2             ', 'SO4             ', &
+                           'NH3             ', 'ACET            ', 'ALD2            ', 'ALK4            ', &
+                           'C2H6            ', 'C3H8            ', 'CH2O            ', 'PRPE            ', &
+                           'MACR            ', 'RCHO            ', 'BCPI            ', 'OCPI            ', &
+                           'HNO2            ', 'NO2             ', 'so4_a1          ', 'num_a1          ', &
+                           'H2O             ', 'bc_a4           ', 'pom_a4          ', 'num_a4          ', &
+                           'MEK             ', 'POG1            ', 'POG2            ', 'MTPA            ', &
+                           'BENZ            ', 'TOLU            ', 'XYLE            ', 'NAP             ', &
+                           'EOH             ', 'MOH             ' /)
 
-      frc_from_dataset(: 1) = (/ .false. /)
+      frc_from_dataset(: 34) = (/ .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false., .false., .false., &
+                                  .false., .false. /)
 
       ! crb_mass(:221) = (/    60.055000_r8,    60.055000_r8,    12.011000_r8,    12.011000_r8,    12.011000_r8, &
       !                       180.165000_r8,    72.066000_r8,    72.066000_r8,    72.066000_r8,    60.055000_r8, &


### PR DESCRIPTION
This is a preliminary commit. Further updates are needed to update the HEMCO_CESM external to the appropriate version, as well as moving up to HEMCO 3.6.0.

- Only emissions in extfrc_lst (in mo_sim_dat) will have 3-D emissions now, as only these will have a 3-D pbuf available to save memory. This is accounted for in cesmgc_emissions_mod.F90.
- The list of species with 3-D emissions in GEOS-Chem are now listed in mo_sim_dat.F90.
- The number of species with 3-D emissions (length of extfrc_lst) is now specified in extcnt in chem_mods.F90.
