### PR TITLE
Updates H2SO4 production rate passed to MAM4 sulfate nucleation

### DIFF
--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -3867,8 +3867,8 @@ contains
     ENDIF
 
     ! Amount of chemically-produced H2SO4 (mol/mol)
-    del_h2so4_gasprod(:nY,:nZ) = vmr1(:nY,:nZ,l_H2SO4) &
-                               - vmr0(:nY,:nZ,l_H2SO4)
+    ! This is archived from fullchem_mod.F90 using SO2 + OH rate from KPP (hplin, 1/25/23)
+    del_h2so4_gasprod(:nY,:nZ) = State_Chm(LCHNK)%H2SO4_PRDR(1,:nY,nZ:1:-1)
 
     call aero_model_gasaerexch( loffset           = iFirstCnst - 1,         &
                                 ncol              = NCOL,                   &


### PR DESCRIPTION
Updates H2SO4 production rate passed to MAM4 sulfate nucleation to use actual H2SO4 production rate computed by KPP in GEOS-Chem (SO2 + OH). This commit requires GEOS-Chem 14.1.1, specifically the field `State_Chm%H2SO4_PRDR` introduced in https://github.com/geoschem/geos-chem/commit/a79ba0c4cbf335642a4c256f35593bfd461e9a62.

The background is as follows:
- H2SO4 production rate is needed for SO4 nucleation in MAM4 to produce more SO4.
- Previously, the H2SO4 production rate (`del_h2so4_gasprod`) was an order of magnitude too low in CESM-GC compared to CAM-chem. This is because GEOS-Chem does not have a H2SO4 tracer; H2SO4 "production rate" is instead computed as the change in H2SO4 after GEOS-Chem time step.
- CESM-GC's coupling to MAM4 simulates the H2SO4 tracer by recording the relative mass contributions of `so4_a1`, `so4_a2`, `so4_a3`, and `h2so4` to the GEOS-Chem bulk `SO4` tracer. This is the `binRatio` (for a1~a3) and `gasRatio` (for h2so4). Because these mass ratios come from MAM4, where sulfate nucleation has just occurred in the previous timestep, `h2so4` is very low since it should have been consumed by nucleation. Thus, `gasRatio` is very low after coming out of the MAM4 timestep, resulting in "change in SO4" * gasRatio = "change in H2SO4" to be abnormally low.
- Daniel and I discussed that the appropriate science fix is to use the `SO2 + OH -> SO4` rate in GEOS-Chem for the H2SO4 production rate. This is recorded in `fullchem_mod.F90`, converted to `mol/mol` production of `H2SO4`, then stored in `State_Chm%H2SO4_PRDR`, which is now used here.

The conversion process is
```fortran
#ifdef MODEL_CESM
       ! Calculate H2SO4 production rate for coupling to CESM (interface to MAM4 nucleation)
       DO F = 1, NFAM

          ! Determine dummy species index in KPP
          KppID =  PL_Kpp_Id(F)

          ! Calculate H2SO4 production rate [mol mol-1] in this timestep (hplin, 1/25/23)
          IF ( TRIM(FAM_NAMES(F)) == 'PSO4' ) THEN
             ! mol/mol = molec cm-3 * g * mol(Air)-1 * kg g-1 * m-3 cm3 / (molec mol-1 * kg m-3)
             !         = mol/molAir
             State_Chm%H2SO4_PRDR(I,J,L) = C(KppID) * AIRMW * 1e-3_fp * 1.0e+6_fp / &
                                 (AVO * State_Met%AIRDEN(I,J,L))

             IF ( State_Chm%H2SO4_PRDR(I,J,L) < 0.0d0) THEN
               write(*,*) "H2SO4_PRDR negative in fullchem_mod.F90!!", &
                  I, J, L, "was:", State_Chm%H2SO4_PRDR(I,J,L), "  setting to 0.0d0"
               State_Chm%H2SO4_PRDR(I,J,L) = 0.0d0
             ENDIF
          ENDIF
       ENDDO
#endif
```