### PR TITLE
Update to use online CLM albedo as default

### DIFF
--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -1167,7 +1167,7 @@ contains
 
        ! onlineAlbedo    -> True  (use CLM albedo)
        !                 -> False (read monthly-mean albedo from HEMCO)
-       Input_Opt%onlineAlbedo           = .False.
+       Input_Opt%onlineAlbedo           = .true.
 
        ! applyQtend: apply tendencies of water vapor to specific humidity
        Input_Opt%applyQtend             = .False.


### PR DESCRIPTION
This will use the online albedo from CLM for CESM-GC simulations instead of using archived, monthly-mean albedo from HEMCO which may be at a lower resolution. We should be using the online albedo for coupled simulations.