### PR TITLE
Set rxt_tag_cnt to 0 in GEOS-Chem as feature is unused

### DIFF
--- a/src/chemistry/geoschem/chem_mods.F90
+++ b/src/chemistry/geoschem/chem_mods.F90
@@ -78,7 +78,7 @@
                             indexm = 1, & ! index of total atm density in invariant array
                             indexh2o = 4, & ! index of water vapor density
                             clsze = 1, & ! loop length for implicit chemistry
-                            rxt_tag_cnt = 95, &
+                            rxt_tag_cnt = 0, & ! number of tagged reactions (unused in GEOS-Chem)
                             enthalpy_cnt = 0, &
                             nslvd = 86  ! number of short-lived (non-advected) species
       integer :: clscnt(5) = 0


### PR DESCRIPTION
This is to fix https://github.com/CESM-GC/CAM/issues/15

> `rxt_tag_cnt` in `chem_mods` currently is set to `95` in `geoschem/chem_mods.F90`:
> 
> ```fortran
>       INTEGER, PARAMETER :: phtcnt = 40, & ! number of photolysis reactions
> !...
>                             rxt_tag_cnt = 95, &
> ```
> 
> However, the corresponding list, `rxt_tag_lst` defined in `chem_mods` and usually populated in `mo_sim_dat` by other chemistry options, is never allocated. This would cause undefined behavior if `get_rxt_ndx` is called in `mo_chem_utls`:
> 
> ```fortran
>   integer function get_rxt_ndx( rxt_tag )
> !...
>     do m = 1,rxt_tag_cnt
>        if( trim( rxt_tag ) == trim( rxt_tag_lst(m) ) ) then
> ```
> 
> We should thus change `rxt_tag_cnt` to `0` in `chem_mods.F90` for GEOS-Chem as we don't use this feature.