### PR TITLE
Fix TSKIN field to correct value

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -84,7 +84,7 @@ local_path = src/chemistry/geoschem/geoschem_src
 required = True
 
 [hemco]
-tag = hemco-cesm1_1_1_hemco3_6_2
+tag = hemco-cesm1_1_3_hemco3_6_2
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 local_path = src/hemco

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -2782,12 +2782,18 @@ contains
     ! Dimensions : nX, nY
     State_Met(LCHNK)%SLP       (1,:nY) = state%ps(:nY)*0.01e+0_fp
 
-    ! Field      : TS, TSKIN
-    ! Description: Surface temperature, surface skin temperature
+    ! Field      : TS
+    ! Description: Surface temperature
     ! Unit       : K
     ! Dimensions : nX, nY
     State_Met(LCHNK)%TS        (1,:nY) = cam_in%TS(:nY)
-    State_Met(LCHNK)%TSKIN     (1,:nY) = cam_in%TS(:nY)
+
+    ! Field      : TSKIN
+    ! Description: Surface skin temperature
+    ! Remarks    : NOT to be confused with TS (T at 2m) (hplin, 3/20/23)
+    ! Unit       : K
+    ! Dimensions : nX, nY
+    State_Met(LCHNK)%TSKIN     (1,:nY) = cam_in%SST(:nY)
 
     ! Field      : SWGDN
     ! Description: Incident radiation @ ground


### PR DESCRIPTION
TSKIN was originally incorrectly defined the same as TS.

TSKIN, the surface skin temperature, should use `cam_in%sst` instead or it will be about 30 kelvins too high.

It will not affect GEOS-Chem directly for now, instead the main effect is in HEMCO (a corresponding fix will be made in HEMCO-CESM shortly). But it will be good to fix this for future reference as well.