### PR TITLE
Update lightning emissions code for compatibility with cesm6_3_111

### DIFF
--- a/src/chemistry/geoschem/geoschem_emissions_mod.F90
+++ b/src/chemistry/geoschem/geoschem_emissions_mod.F90
@@ -76,7 +76,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE GC_Emissions_Init( lght_no_prd_factor )
+  SUBROUTINE GC_Emissions_Init( )
 !
 ! !USES:
 !
@@ -85,14 +85,9 @@ CONTAINS
     USE PHYS_CONTROL,        ONLY : phys_getopts
     USE MO_CHEM_UTLS,        ONLY : get_spc_ndx, get_extfrc_ndx
     USE CAM_HISTORY,         ONLY : addfld, add_default, horiz_only
-    USE MO_LIGHTNING,        ONLY : lightning_inti
     USE FIRE_EMISSIONS,      ONLY : fire_emissions_init
     USE CHEM_MODS,           ONLY : adv_mass
     USE INFNAN,              ONLY : NaN, assignment(=)
-!
-! !INPUT PARAMETERS:
-!
-    REAL(r8),                INTENT(IN   ) :: lght_no_prd_factor ! Lightning scaling factor
 !
 ! !REVISION HISTORY:
 !  07 Oct 2020 - T. M. Fritz   - Initial version
@@ -126,11 +121,6 @@ CONTAINS
 
     ! Get constituent index for NO
     CALL cnst_get_ind('NO', iNO, abort=.True.)
-
-    !-----------------------------------------------------------------------
-    !	... initialize the lightning module
-    !-----------------------------------------------------------------------
-    CALL lightning_inti(lght_no_prd_factor)
 
     !-----------------------------------------------------------------------
     ! ... MEGAN emissions


### PR DESCRIPTION
Updates to the lightning emissions code in GEOS-Chem are necessary when updating from cam3_6_095 to cam3_6_111. This is due to upstream changes in `mo_lightning.F90`. Changes in this PR include:

1. Call `mo_lightning` module routine `lightning_readnl` to read parameter `lght_no_prd_factor` from input file. CAM 3.6.111 stores this namelist parameter in `lightning_nl` rather than `chem_inparm` and now has its own subroutine to read  and broadcast the parameter.
2. Remove local variables for `lght_no_prd_factor` from GEOS-Chem interface code and also remove it from the argument list for emissions initialization. It is no longer needed to initialize the lightning module.
3. Change the lightning module initialization call from `lightning_inti` to `lightning_init`, and no longer pass the NO prod factor.