### PR TITLE
Exit with warning in build-namelist if HEMCO config files are specified in user namelist

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2960,10 +2960,27 @@ if ($nl->get_value('use_hemco') =~ m/$TRUE/io) {
     $nl->delete_variable('chem_inparm', 'ext_frc_specifier');
     $nl->delete_variable('chem_inparm', 'srf_emis_specifier');
 
-    # If using GEOS-Chem reset paths of HEMCO configuration files to local filename only
     if ($chem =~ /geoschem/) {
-	$nl->set_variable_value('hemco_nl', 'hemco_config_file', "'HEMCO_Config.rc'");
-	$nl->set_variable_value('hemco_nl', 'hemco_diagn_file', "'HEMCO_Diagn.rc'");
+
+        # For now, HEMCO config and diagnostic configuration files are always used from
+        # the case directory. Exit if user has specified other paths in the user namelist
+        # because it will not work.
+        if ($nl->get_value('hemco_config_file') ne "'" . $inputdata_rootdir . "/HEMCO_Config.rc'") {
+            die "CAM Namelist ERROR: When running with GEOS-Chem chemistry, hemco_config_file\n".
+                "must not be manually set in the namelist. Instead, modify (or symlink from) the HEMCO_Config.rc\n".
+                "in the case directory, which will be copied to the run directory when submitting,\n".
+                "Then remove the hemco_config_file option from the user namelist.\n";
+        }
+
+        if ($nl->get_value('hemco_diagn_file') ne "'" . $inputdata_rootdir . "/HEMCO_Diagn.rc'") {
+            die "CAM Namelist ERROR: When running with GEOS-Chem chemistry, hemco_diagn_file\n".
+                "must not be manually set in the namelist. Instead, modify (or symlink from) the HEMCO_Diagn.rc\n".
+                "in the case directory, which will be copied to the run directory when submitting.\n".
+                "Then remove the hemco_diagn_file option from the user namelist.\n";
+        }
+
+        $nl->set_variable_value('hemco_nl', 'hemco_config_file', "'HEMCO_Config.rc'");
+	    $nl->set_variable_value('hemco_nl', 'hemco_diagn_file', "'HEMCO_Diagn.rc'");
     }
 }
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2968,7 +2968,7 @@ if ($nl->get_value('use_hemco') =~ m/$TRUE/io) {
         if ($nl->get_value('hemco_config_file') ne "'" . $inputdata_rootdir . "/HEMCO_Config.rc'") {
             die "CAM Namelist ERROR: When running with GEOS-Chem chemistry, hemco_config_file\n".
                 "must not be manually set in the namelist. Instead, modify (or symlink from) the HEMCO_Config.rc\n".
-                "in the case directory, which will be copied to the run directory when submitting,\n".
+                "in the case directory, which will be copied to the run directory when submitting.\n".
                 "Then remove the hemco_config_file option from the user namelist.\n";
         }
 
@@ -2980,7 +2980,7 @@ if ($nl->get_value('use_hemco') =~ m/$TRUE/io) {
         }
 
         $nl->set_variable_value('hemco_nl', 'hemco_config_file', "'HEMCO_Config.rc'");
-	    $nl->set_variable_value('hemco_nl', 'hemco_diagn_file', "'HEMCO_Diagn.rc'");
+        $nl->set_variable_value('hemco_nl', 'hemco_diagn_file', "'HEMCO_Diagn.rc'");
     }
 }
 


### PR DESCRIPTION
Current behavior in build-namelist enforces use of config files in case directory which are copied to run directory at submit time. 

User customization to user_nl_cam for the path of HEMCO config files will not take effect when running with GEOS-Chem chemistry, instead the user should edit or symlink from the files in the case directory similar to standalone GEOS-Chem operation. 

This commit adds a check in build-namelist for this customization and aborts with error to warn user that this is unsupported.

Thanks!
Haipeng