### PR TITLE
Fixes for compatibility with SE dycore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
 	path = src/chemistry/geoschem/geoschem_src
 	url = https://github.com/geoschem/geos-chem.git
         fxrequired = AlwaysRequired
-        fxtag = geoschem_14.4_in_cesm
+        fxtag = feature/geoschem_14.4_in_cesm
         fxDONOTUSEurl = https://github.com/geoschem/geos-chem.git
 
 [submodule "cloud_j"]

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -1223,6 +1223,10 @@ contains
           CALL Error_Stop( ErrMsg, ThisLoc )
        ENDIF
 
+       ! Set grid metadata. This has to be after State_Grid is initialized.
+       State_Grid(I)%ID = I
+       State_Grid(I)%ROOT_ID = BEGCHUNK
+
        State_Grid(I)%NX = nX
        State_Grid(I)%NY = NCOL(I)
        State_Grid(I)%NZ = nZ
@@ -1613,16 +1617,20 @@ contains
     IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
          Input_Opt%ITS_AN_AEROSOL_SIM ) THEN
        DO I = BEGCHUNK, ENDCHUNK
-          ! Restrict prints to one thread only
-          Input_Opt%amIRoot = (MasterProc .AND. (I == BEGCHUNK))
-
           CALL Init_Photolysis( Input_Opt  = Input_Opt,                &
                                 State_Grid = State_Grid(I),            &
                                 State_Chm  = State_Chm(I),             &
                                 State_Diag = State_Diag(I),            &
                                 RC         = RC                       )
+
+          ! Only the root chunk (on all CPUs) should be reading the data
+          ! in State_Chm%Phot%OREF and State_Chm%Phot%TREF, and the rest should be copied.
+          ! This fixes a hang condition in the ne30 (SE dycore) compsets. (hplin, 7/3/24)
+          IF( I .ne. BEGCHUNK ) THEN
+            State_Chm(I)%Phot%TREF = State_Chm(BEGCHUNK)%Phot%TREF
+            State_Chm(I)%Phot%OREF = State_Chm(BEGCHUNK)%Phot%OREF
+          ENDIF
        ENDDO
-       Input_Opt%amIRoot = MasterProc
 
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Photolysis"!'
@@ -1650,7 +1658,7 @@ contains
               CALL mpi_bcast( State_Chm(I)%NOXCOEFF, size(State_Chm(I)%NOXCOEFF), mpi_real8, masterprocid, mpicom, ierr )
               IF ( ierr /= mpi_success ) CALL endrun('Error in mpi_bcast of NOXCOEFF in first chunk')
            ELSE
-              State_CHM(I)%NOXCOEFF = State_Chm(BEGCHUNK)%NOXCOEFF
+              State_Chm(I)%NOXCOEFF = State_Chm(BEGCHUNK)%NOXCOEFF
            ENDIF
         ENDDO
     ENDIF

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -1224,8 +1224,8 @@ contains
        ENDIF
 
        ! Set grid metadata. This has to be after State_Grid is initialized.
-       State_Grid(I)%ID = I
-       State_Grid(I)%ROOT_ID = BEGCHUNK
+       State_Grid(I)%CPU_Subdomain_ID = I
+       State_Grid(I)%CPU_Subdomain_FirstID = BEGCHUNK
 
        State_Grid(I)%NX = nX
        State_Grid(I)%NY = NCOL(I)


### PR DESCRIPTION
This is a companion PR to https://github.com/geoschem/geos-chem/pull/2366 -- this must be added to GEOS-Chem first to enable `State_Grid%ID` and `State_Grid%ROOT_ID`

## Problem cause

`CAM_PIO_OPENFILE` is a collective operation and on SE grids the assumption that all CPUs have the same # of chunks does not work. This assumption was implicitly made in `photolysis_init`.

This works for `drydep_mod` because `CAM_PIO_OPENFILE` is called by each CPU and not per chunk, but for `photolysis_init` it is called by chunk because it populates fields in `State_Chm`.

## Fix

This update changes `photolysis_init` to only run on the first chunk in each CPU. This is made possible by letting GEOS-Chem be aware of which chunk it is running on via `State_Grid%ID`.